### PR TITLE
Fix loading animation fade out

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
       transition: opacity 0.5s, visibility 0.5s;
     }
     
-    .loading-overlay.hidden {
+    .loading-overlay.fade-out {
       opacity: 0;
       visibility: hidden;
     }
@@ -702,7 +702,7 @@
     // Loading Animation
     window.addEventListener('load', () => {
       setTimeout(() => {
-        document.getElementById('loading').classList.add('hidden');
+        document.getElementById('loading').classList.add('fade-out');
       }, 1000);
     });
 


### PR DESCRIPTION
## Summary
- rename `loading-overlay.hidden` style to `loading-overlay.fade-out`
- use `fade-out` class in script instead of Tailwind `hidden`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d19e6f43483319bb241e2cba949f3