### PR TITLE
Fix skill tag contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,8 @@
     }
     
     .skill-tag {
-      background: var(--primary-gradient);
+      background-color: #e4545b;
+      color: #ffffff;
       transition: all 0.15s ease;
       position: relative;
       overflow: hidden;


### PR DESCRIPTION
## Summary
- set explicit color and background color on skill tags to improve readability

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e3f3bd1dc8331a77e4684dd07eb15