### PR TITLE
Fix uneven about stats card height

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,6 +335,7 @@
 
         #about .stats-grid {
             grid-auto-rows: 1fr;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
         }
 
         #about .stats-grid .card {
@@ -342,6 +343,8 @@
             flex-direction: column;
             justify-content: center;
             align-items: center;
+            min-height: 150px;
+            height: 100%;
         }
 
         /* Skills section */


### PR DESCRIPTION
## Summary
- ensure stats cards in the About section use a responsive grid
- give the cards a consistent minimum height

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d246e56a88331a3c963d43acd3c1b