### PR TITLE
Update certification icons with proper styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,7 @@
             color: white;
             font-size: 18px;
         }
+        .cert-icon { width: 40px; height: 40px; object-fit: contain; margin-right: 0.75rem; display: flex; align-items: center; justify-content: center; background: var(--gradient-primary); color: white; border-radius: 8px; }
 
         /* Experience timeline */
         .timeline {
@@ -1145,87 +1146,87 @@
             </div>
             <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-redhat" role="img" aria-label="Red Hat Certified Architect badge"></i>
                     <p class="font-semibold text-gray-800">Red Hat Certified Architect in Infrastructure</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-redhat" role="img" aria-label="Red Hat Certified Openstack System Administrator badge"></i>
                     <p class="font-semibold text-gray-800">RedHat Certified Openstack System Administrator</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-redhat" role="img" aria-label="Red Hat Certified Openshift Specialist badge"></i>
                     <p class="font-semibold text-gray-800">RedHat Certified Openshift Specialist</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ansible" role="img" aria-label="Red Hat Certified Specialist in Advanced Automation badge"></i>
                     <p class="font-semibold text-gray-800">Red Hat Certified Specialist in Advanced Automation</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fas fa-server" role="img" aria-label="Red Hat Certified Specialist in Virtualization badge"></i>
                     <p class="font-semibold text-gray-800">Red Hat Certified Specialist in Virtualization</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ansible" role="img" aria-label="Red Hat Certified Specialist in Ansible Automation badge"></i>
                     <p class="font-semibold text-gray-800">Red Hat Certified Specialist in Ansible Automation</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ansible" role="img" aria-label="Red Hat Certified Engineer in Ansible and Red Hat Linux 8 badge"></i>
                     <p class="font-semibold text-gray-800">RedHat Certified Engineer in Ansible and RedHat Linux 8</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-redhat" role="img" aria-label="Red Hat Certified System Administrator in Red Hat Linux 7 badge"></i>
                     <p class="font-semibold text-gray-800">RedHat Certified System Administrator in Redhat Linux 7</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="Architectural Thinking (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Architectural Thinking (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="Architect Foundations (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Architect Foundations (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="IBM Design Thinking Practitioner (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">IBM Design Thinking Practitioner (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="Enterprise IT Transformation Advisor Level 4 (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Enterprise IT Transformation Advisor Level 4 (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-docker" role="img" aria-label="Docker Essentials (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Docker Essentials (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="IBM Cloud Private Infrastructure and Architecture (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">IBM Cloud Private Infrastructure and Architecture (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="IBM Recognised speaker presenter (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">IBM Recognised speaker presenter (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="IBM Recognised Teacher/Educator (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">IBM Recognised Teacher/Educator (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="Team Solution Design (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Team Solution Design (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-ibm" role="img" aria-label="Build Your Own Chatbot - Level 1 (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Build Your Own Chatbot - Level 1 (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fab fa-kubernetes" role="img" aria-label="Get started with Kubernetes and IBM Cloud Container Service (IBM Badge)"></i>
                     <p class="font-semibold text-gray-800">Get started with Kubernetes and IBM Cloud Container Service (IBM Badge)</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fas fa-network-wired" role="img" aria-label="ScienceLogic Certified Professional badge"></i>
                     <p class="font-semibold text-gray-800">ScienceLogic Certified Professional</p>
                 </div>
                 <div class="cert-card animate-fade-in-up">
-                    <div class="skill-icon"><i class="fas fa-certificate"></i></div>
+                    <i class="cert-icon fas fa-book" role="img" aria-label="ITIL v3 foundation certified badge"></i>
                     <p class="font-semibold text-gray-800">ITIL v3 foundation certified</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add `.cert-icon` utility class for consistent icon size and fallback styling
- show brand icons for each certification with accessible labels

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686fe00348448331a0e104daafa1fa91